### PR TITLE
use /v2/users/me/project_assignments to fix #3, #8

### DIFF
--- a/info.plist
+++ b/info.plist
@@ -1558,7 +1558,7 @@ https://github.com/ajilderda/alfred-harvest-v2</string>
 	<key>variablesdontexport</key>
 	<array/>
 	<key>version</key>
-	<string>1.1.1</string>
+	<string>1.1.3</string>
 	<key>webaddress</key>
 	<string>https://github.com/ajilderda/alfred-harvest-v2</string>
 </dict>

--- a/src/list-project-tasks.js
+++ b/src/list-project-tasks.js
@@ -1,5 +1,4 @@
 import { alfredError } from './utils/errors';
-import { apiCall } from './utils/helpers';
 const alfy = require('alfy');
 
 const vars = process.env;
@@ -23,6 +22,6 @@ try {
         }));
 
     alfy.output(items);
-} catch(error) {
+} catch (error) {
     alfredError(error, 'Failed to list project tasks.');
 }

--- a/src/list-project-tasks.js
+++ b/src/list-project-tasks.js
@@ -3,33 +3,26 @@ import { apiCall } from './utils/helpers';
 const alfy = require('alfy');
 
 const vars = process.env;
-const { projectId } = vars;
+const { task_assignments } = vars;
 
-const url = 'https://api.harvestapp.com/v2/users/me/project_assignments'
+try {
+    const items = alfy
+        .inputMatches(JSON.parse(task_assignments), 'task.name')
+        .filter(element => element.is_active)
+        .map(element => ({
+            uid: element.id,
+            title: element.task.name,
+            subtitle: 'Start this task',
+            variables: {
+                taskId: element.task.id,
+                taskName: element.task.name
+            },
+            icon: {
+                path: 'src/icons/start.png'
+            }
+        }));
 
-
-await apiCall(url, 'GET')
-    .then(response => {
-        const project = response.project_assignments.filter(element => element.project.id == projectId )[0]
-
-        const items = alfy
-            .inputMatches(project.task_assignments, 'task.name')
-            .filter(element => element.is_active)
-            .map(element => ({
-                uid: element.id,
-                title: element.task.name,
-                subtitle: 'Start this task',
-                variables: {
-                    taskId: element.task.id,
-                    taskName: element.task.name
-                },
-                icon: {
-                    path: 'src/icons/start.png'
-                }
-            }));
-
-        alfy.output(items);
-    })
-    .catch(error => {
-        alfredError(error, 'Failed to list project tasks.');
-    });
+    alfy.output(items);
+} catch(error) {
+    alfredError(error, 'Failed to list project tasks.');
+}

--- a/src/list-project-tasks.js
+++ b/src/list-project-tasks.js
@@ -5,12 +5,15 @@ const alfy = require('alfy');
 const vars = process.env;
 const { projectId } = vars;
 
-const url = `https://api.harvestapp.com/v2/projects/${projectId}/task_assignments`;
+const url = 'https://api.harvestapp.com/v2/users/me/project_assignments'
+
 
 await apiCall(url, 'GET')
     .then(response => {
+        const project = response.project_assignments.filter(element => element.project.id == projectId )[0]
+
         const items = alfy
-            .inputMatches(response.task_assignments, 'task.name')
+            .inputMatches(project.task_assignments, 'task.name')
             .filter(element => element.is_active)
             .map(element => ({
                 uid: element.id,

--- a/src/list-projects.js
+++ b/src/list-projects.js
@@ -15,7 +15,8 @@ await apiCall(url, 'GET')
                 subtitle: 'View available tasks',
                 variables: {
                     projectId: element.project.id,
-                    projectName: element.project.name
+                    projectName: element.project.name,
+                    task_assignments: JSON.stringify(element.task_assignments)
                 },
                 icon: {
                     path: 'src/icons/start-new.png'

--- a/src/list-projects.js
+++ b/src/list-projects.js
@@ -3,19 +3,19 @@ import { apiCall } from './utils/helpers';
 const alfy = require('alfy');
 
 
-const url = 'https://api.harvestapp.com/v2/projects';
+const url = 'https://api.harvestapp.com/v2/users/me/project_assignments';
 
 await apiCall(url, 'GET')
     .then(response => {
-        const items = alfy.inputMatches(response.projects, 'name')
+        const items = alfy.inputMatches(response.project_assignments, 'project.name')
             .filter(element => element.is_active)
             .map(element => ({
-                uid: element.id,
-                title: `${element.name}, ${element.client.name}`,
+                uid: element.project.id,
+                title: `${element.project.name}, ${element.client.name}`,
                 subtitle: 'View available tasks',
                 variables: {
-                    projectId: element.id,
-                    projectName: element.name
+                    projectId: element.project.id,
+                    projectName: element.project.name
                 },
                 icon: {
                     path: 'src/icons/start-new.png'

--- a/src/list-projects.js
+++ b/src/list-projects.js
@@ -2,29 +2,50 @@ import { alfredError } from './utils/errors';
 import { apiCall } from './utils/helpers';
 const alfy = require('alfy');
 
+const url = 'https://api.harvestapp.com/v2/users/me/project_assignments?';
 
-const url = 'https://api.harvestapp.com/v2/users/me/project_assignments';
+const formatOutput = element => ({
+    uid: element.project.id,
+    title: `${element.project.name}, ${element.client.name}`,
+    subtitle: 'View available tasks',
+    variables: {
+        projectId: element.project.id,
+        projectName: element.project.name,
+        task_assignments: JSON.stringify(element.task_assignments)
+    },
+    icon: {
+        path: 'src/icons/start-new.png'
+    }
+});
 
 await apiCall(url, 'GET')
     .then(response => {
-        const items = alfy.inputMatches(response.project_assignments, 'project.name')
-            .filter(element => element.is_active)
-            .map(element => ({
-                uid: element.project.id,
-                title: `${element.project.name}, ${element.client.name}`,
-                subtitle: 'View available tasks',
-                variables: {
-                    projectId: element.project.id,
-                    projectName: element.project.name,
-                    task_assignments: JSON.stringify(element.task_assignments)
-                },
-                icon: {
-                    path: 'src/icons/start-new.png'
-                }
-            }));
+        if (response.total_pages === 1) {
+            const items = alfy.inputMatches(response.project_assignments, 'project.name')
+                .filter(element => element.is_active)
+                .map(formatOutput);
 
-        alfy.output(items);
+            alfy.output(items);
+        }
+        // if user has over 100 projects, retrieve all pages and wait for
+        // promises to be resolved
+        else {
+            const pageRequests = [];
+            for (let i = response.page + 1; i <= response.total_pages; i++) {
+                pageRequests.push(apiCall(`${url}&page=${i}`))
+            }
 
+            Promise.all(pageRequests).then(pages => {
+                const projectAssignments = pages
+                    .reduce((acc, page) => {
+                        return [...acc, ...page.project_assignments]
+                    }, [])
+                    .filter(element => element.is_active)
+                    .map(formatOutput);
+
+                alfy.output(projectAssignments);
+            })
+        }
     })
     .catch(error => {
         alfredError(error, 'Failed to list projects.');


### PR DESCRIPTION
It's quick and dirty, (still) doesn't address cases where the user is assigned to >100 projects (in which case you need to unroll the pagination from the API, this one or the ones you were using before)

but it doesn't require admin permissions this way